### PR TITLE
Fix markdown parser

### DIFF
--- a/src/Collections/Markdown.php
+++ b/src/Collections/Markdown.php
@@ -4,6 +4,7 @@ namespace Damcclean\Systatic\Collections;
 
 use Damcclean\Systatic\Parsers\Yaml;
 use Damcclean\Systatic\Config\Config;
+use Damcclean\Systatic\Plugins\Compiler;
 use Damcclean\Systatic\Parsers\ParsedownExtra;
 
 class Markdown
@@ -13,6 +14,7 @@ class Markdown
         $this->config = new Config();
         $this->markdown = new ParsedownExtra();
         $this->yaml = new Yaml();
+        $this->compiler = new Compiler();
     }
 
     public function parse(string $file, array $collection)
@@ -51,18 +53,24 @@ class Markdown
         }
 
         if (array_key_exists('view', $frontMatter)) {
-            if (file_exists($this->config->get('locations.views') . '/' . $frontMatter['view'] . '.blade.php')) {
-                $view = $frontMatter['view'];
-            } elseif (file_exists($this->config->get('locations.views') . '/' . str_replace('.', '/', $frontMatter['view']) . '.blade.php')) {
-                $view = str_replace('.', '/', $frontMatter['view']);
+            foreach($this->compiler->getExtensions() as $extension) {
+                if (file_exists($this->config->get('locations.views') . '/' . $frontMatter['view'] . $extension)) {
+                    $view = $frontMatter['view'];
+                } elseif(file_exists($this->config->get('locations.views') . '/' . str_replace('.', '/', $frontMatter['view']) . $extension)) {
+                    $view = str_replace('.', '/', $frontMatter['view']);
+                }
             }
         } elseif (array_key_exists('view', $collection)) {
-            if (file_exists($this->config->get('locations.views') . '/' . $collection['view'] . '.blade.php')) {
-                $view = $collection['view'];
+            foreach($this->compiler->getExtensions() as $extension) {
+                if (file_exists($this->config->get('locations.views') . '/' . $collection['view'] . $extension)) {
+                    $view = $collection['view'];
+                }
             }
         } elseif ($slug !== 'index') {
-            if (file_exists($this->config->get('locations.views') . '/' . $slug . '.blade.php')) {
-                $view = $slug;
+            foreach($this->compiler->getExtensions() as $extension) {
+                if (file_exists($this->config->get('locations.views') . '/' . $slug . $extension)) {
+                    $view = $slug;
+                }
             }
         }
 

--- a/src/Collections/Remote.php
+++ b/src/Collections/Remote.php
@@ -3,6 +3,7 @@
 namespace Damcclean\Systatic\Collections;
 
 use Damcclean\Systatic\Config\Config;
+use Damcclean\Systatic\Plugins\Compiler;
 
 class Remote
 {
@@ -11,6 +12,7 @@ class Remote
     public function __construct()
     {
         $this->config = new Config();
+        $this->compiler = new Compiler();
     }
 
     public function process(array $collection)
@@ -45,14 +47,18 @@ class Remote
         if (array_key_exists('slug', $entry)) {
             $slug = $entry['slug'];
 
-            if (file_exists($this->config->get('locations.views') . '/' . $slug . '.blade.php')) {
-                $view = $entry['slug'];
+            foreach($this->compiler->getExtensions() as $extension) {
+                if (file_exists($this->config->get('locations.views') . '/' . $slug . $extension)) {
+                    $view = $entry['slug'];
+                }
             }
         }
 
         if (array_key_exists('view', $entry)) {
-            if (file_exists($this->config->get('locations.views') . '/' . $view . '.blade.php')) {
-                $view = $entry['view'];
+            foreach($this->compiler->getExtensions() as $extension) {
+                if (file_exists($this->config->get('locations.views') . '/' . $view . $extension)) {
+                    $view = $entry['view'];
+                }
             }
         }
 

--- a/src/Parsers/ParsedownExtra.php
+++ b/src/Parsers/ParsedownExtra.php
@@ -13,6 +13,15 @@ class ParsedownExtra
 
     public function parse(string $contents)
     {
+        $contents = $this->stripYaml($contents);
         return $this->parser->text($contents);
+    }
+
+    public function stripYaml(string $contents)
+    {
+        $contents = preg_replace('/---/', '=====', $contents, 1);   // Replace first --- with --
+        $contents = substr(strstr($contents, '---'), strlen('---'));   // Remove everything before ---
+
+        return $contents;
     }
 }

--- a/src/Parsers/ParsedownExtra.php
+++ b/src/Parsers/ParsedownExtra.php
@@ -19,9 +19,6 @@ class ParsedownExtra
 
     public function stripYaml(string $contents)
     {
-        $contents = preg_replace('/---/', '=====', $contents, 1);   // Replace first --- with --
-        $contents = substr(strstr($contents, '---'), strlen('---'));   // Remove everything before ---
-
-        return $contents;
+         return preg_replace('/^(---(?s)(.*?)---)/i', '', $contents);
     }
 }

--- a/src/Parsers/Yaml.php
+++ b/src/Parsers/Yaml.php
@@ -12,10 +12,10 @@ class Yaml
         return SymfonyYaml::parse($contents);
     }
 
-    private function stripContent(string $content)
+    private function stripContent(string $contents)
     {
-        $content = substr($content, 0, strpos($content, '---', strpos($content, '---') + 1));
-        $content = str_replace('---', '', $content);
-        return $content;
+        $contents = substr($contents, 0, strpos($contents, '---', strpos($contents, '---') + 1));
+        $contents = str_replace('---', '', $contents);
+        return $contents;
     }
 }

--- a/src/Plugins/Compiler.php
+++ b/src/Plugins/Compiler.php
@@ -14,4 +14,21 @@ class Compiler extends Store
 
         return $this->get();
     }
+
+    public function getExtensions()
+    {
+    	$extensions = [
+    		'.blade.php'
+    	];
+    	
+    	$compilers = $this->get();
+
+    	foreach($compilers as $compiler) {
+    		foreach($compiler['extensions'] as $extension) {
+    			$extensions[] = $extension;
+    		}
+    	}
+
+    	return $extensions;
+    }
 }

--- a/tests/Unit/ParsedownExtraParserTest.php
+++ b/tests/Unit/ParsedownExtraParserTest.php
@@ -21,4 +21,13 @@ class ParsedownExtraParserTest extends TestCase
 
         $this->assertSame('<h1>This is my <strong>heading</strong></h1>', $parser);
     }
+
+    public function testCanParseMarkdownContentsWithFrontMatter()
+    {
+        $markdown = file_get_contents('./tests/fixtures/yaml-test.md');
+
+        $parser = $this->parser->parse($markdown);
+
+        $this->assertSame('<p>Keep these dates in your diary!</p>', $parser);
+    }
 }


### PR DESCRIPTION
# Description
Fixes the markdown parser issues where it was not stripping out front matter before actually sending it to be parsed. I've also added tests to verify that this fix works.